### PR TITLE
Add py.typed file

### DIFF
--- a/sourcetypes/setup.py
+++ b/sourcetypes/setup.py
@@ -14,6 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/samwillis/python-inline-source/sourcetypes",
     py_modules=['sourcetypes'],
+    package_data={'sourcetypes': ['py.typed']},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
When using pylance/pyright you get a missing stub file error, see:

<img src="https://github.com/samwillis/python-inline-source/assets/667029/46724c53-31a1-4892-8a26-0da807300093" width="500">

And this makes all usages of types trigger an error:


<img src="https://github.com/samwillis/python-inline-source/assets/667029/a43bd08e-5a24-4611-9905-254394ded0c1" width="500">

In order to fix this we need to tell the typechecker that this library is typed, by adding the py.typed file :)

See: https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/

@samwillis let me know if I should bump the version too!